### PR TITLE
better 401 error handling in narrative

### DIFF
--- a/config/narrative.nginx
+++ b/config/narrative.nginx
@@ -123,8 +123,9 @@ server {
 	}
 
         location /narrative/ {
-
+ 
              default_type 'text/plain';
+             error_page 401 /index.html;
  
              set $target '';
 
@@ -254,6 +255,7 @@ server {
         location /narrative/ {
 
              default_type 'text/plain';
+             error_page 401 /index.html;
  
              set $target '';
 


### PR DESCRIPTION
Redirect 401 errors (auth required; comes from lua) to the front login page.  Addresses part of https://atlassian.kbase.us/browse/NAR-686 .