### PR TITLE
user.rules file

### DIFF
--- a/config/narrative_ufw/user.rules
+++ b/config/narrative_ufw/user.rules
@@ -1,0 +1,60 @@
+*filter
+:ufw-user-input - [0:0]
+:ufw-user-output - [0:0]
+:ufw-user-forward - [0:0]
+:ufw-before-logging-input - [0:0]
+:ufw-before-logging-output - [0:0]
+:ufw-before-logging-forward - [0:0]
+:ufw-user-logging-input - [0:0]
+:ufw-user-logging-output - [0:0]
+:ufw-user-logging-forward - [0:0]
+:ufw-after-logging-input - [0:0]
+:ufw-after-logging-output - [0:0]
+:ufw-after-logging-forward - [0:0]
+:ufw-logging-deny - [0:0]
+:ufw-logging-allow - [0:0]
+:ufw-user-limit - [0:0]
+:ufw-user-limit-accept - [0:0]
+### RULES ###
+
+### tuple ### allow any any 0.0.0.0/0 any 198.128.58.0/24 in
+-A ufw-user-input -s 198.128.58.0/24 -j ACCEPT
+
+### tuple ### allow any any 0.0.0.0/0 any 10.58.0.0/22 in
+-A ufw-user-input -s 10.58.0.0/22 -j ACCEPT
+
+### tuple ### allow any 80 0.0.0.0/0 any 0.0.0.0/0 in
+-A ufw-user-input -p tcp --dport 80 -j ACCEPT
+-A ufw-user-input -p udp --dport 80 -j ACCEPT
+
+### tuple ### allow any 443 0.0.0.0/0 any 0.0.0.0/0 in
+-A ufw-user-input -p tcp --dport 443 -j ACCEPT
+-A ufw-user-input -p udp --dport 443 -j ACCEPT
+
+### tuple ### allow any 6556 0.0.0.0/0 any 10.58.0.0/22 in
+-A ufw-user-input -p tcp --dport 6556 -s 10.58.0.0/22 -j ACCEPT
+-A ufw-user-input -p udp --dport 6556 -s 10.58.0.0/22 -j ACCEPT
+
+### tuple ### allow any 7068 0.0.0.0/0 any 172.17.0.0/16 in
+-A ufw-user-input -p tcp --dport 7068 -s 172.17.0.0/16 -j ACCEPT
+-A ufw-user-input -p udp --dport 7068 -s 172.17.0.0/16 -j ACCEPT
+
+### tuple ### allow tcp 32000:33000 172.17.42.1 any 172.17.0.0/16 in
+-A ufw-user-input -p tcp -m multiport --dports 32000:33000 -d 172.17.42.1 -s 172.17.0.0/16 -j ACCEPT
+
+### END RULES ###
+
+### LOGGING ###
+-A ufw-after-logging-input -j LOG --log-prefix "[UFW BLOCK] " -m limit --limit 3/min --limit-burst 10
+-A ufw-after-logging-forward -j LOG --log-prefix "[UFW BLOCK] " -m limit --limit 3/min --limit-burst 10
+-I ufw-logging-deny -m conntrack --ctstate INVALID -j RETURN -m limit --limit 3/min --limit-burst 10
+-A ufw-logging-deny -j LOG --log-prefix "[UFW BLOCK] " -m limit --limit 3/min --limit-burst 10
+-A ufw-logging-allow -j LOG --log-prefix "[UFW ALLOW] " -m limit --limit 3/min --limit-burst 10
+### END LOGGING ###
+
+### RATE LIMITING ###
+-A ufw-user-limit -m limit --limit 3/minute -j LOG --log-prefix "[UFW LIMIT BLOCK] "
+-A ufw-user-limit -j REJECT
+-A ufw-user-limit-accept -j ACCEPT
+### END RATE LIMITING ###
+COMMIT


### PR DESCRIPTION
This is the user.rules file needed to create the proper firewall rules needed for narrative and its helpers.

port 7068: narrative job proxy
32000:33000 : narrative log proxy
