### PR TITLE
add 401 directive

### DIFF
--- a/config/narrative.nginx
+++ b/config/narrative.nginx
@@ -104,6 +104,15 @@ server {
 
 	}
 
+        location /narrative_shutdown {
+             allow 127.0.0.1;
+             default_type 'application/json';
+
+             set $uri_base '/proxy_map';
+             content_by_lua 'proxymgr:narrative_shutdown()';
+
+        }
+
 	# Statically bound workspace1 instance for Paramvir
 	location /workspace1 {
              default_type 'text/plain';
@@ -125,6 +134,7 @@ server {
         location /narrative/ {
 
              default_type 'text/plain';
+             error_page 401 /index.html;
  
              set $target '';
 
@@ -254,6 +264,7 @@ server {
         location /narrative/ {
 
              default_type 'text/plain';
+             error_page 401 /index.html;
  
              set $target '';
 


### PR DESCRIPTION
Adds 401 directives to send unauthorized (unlogged-in) users to home page; add narrative-shutdown to port 80 server (maybe not needed but let's keep consistent).  These changes may already be in dev, so we could reject this PR if we pull changes from dev to master.