### PR TITLE
Fastupdate

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ perl:
   - "5.20"
 
 
-script: "printenv;make KB_RUNTIME=$PERLBREW_HOME/perls/$PERLBREW_PERL test"
+script: "printenv;make KB_RUNTIME=$PERLBREW_ROOT/perls/$PERLBREW_PERL test"
 
 after_failure: "cat /tmp/dc*/dep*log"

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ perl:
 
 script: "make test"
 
-after_failure: "cat /tmp/dc*/dep*log"
+after_failure: "find /tmp;cat /tmp/dc*/dep*log"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ perl:
   - "5.20"
 
 
-script: "make test"
+script: "printenv;make test"
 
-after_failure: "find /tmp;cat /tmp/dc*/dep*log"
+after_failure: "cat /tmp/dc*/dep*log"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ perl:
   - "5.20"
 
 
-script: "printenv;make test"
+script: "printenv;PERL5LIB=$PERLBREW_ROOT/perls/$PERLBREW_PERL/lib/$PERLBREW_PERL:$PERL5LIB make test"
 
-after_failure: "cat /tmp/dc*/dep*log"
+after_failure: "cat /tmp/dc*/dep*log;find $PERLBREW_ROOT"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ perl:
   - "5.20"
 
 
-script: "printenv;PERL5LIB=$PERLBREW_ROOT/perls/$PERLBREW_PERL/lib/$PERLBREW_PERL:$PERL5LIB make test"
+script: "printenv;make KB_RUNTIME=$PERLBREW_HOME/perls/$PERLBREW_PERL test"
 
-after_failure: "cat /tmp/dc*/dep*log;find $PERLBREW_ROOT"
+after_failure: "cat /tmp/dc*/dep*log"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,6 @@ perl:
   - "5.20"
 
 
-script: "printenv;make KB_RUNTIME=$PERLBREW_ROOT/perls/$PERLBREW_PERL test"
+script: "make KB_RUNTIME=$PERLBREW_ROOT/perls/$PERLBREW_PERL test"
 
 after_failure: "cat /tmp/dc*/dep*log"

--- a/t/config/postprocess_kbtestserv
+++ b/t/config/postprocess_kbtestserv
@@ -1,0 +1,16 @@
+#!/usr/bin/env perl
+
+use FindBin;
+use lib "$FindBin::Bin/../../perl/";
+use KBDeploy;
+use strict;
+
+print STDER "$ENV{KB_CONFIG}\n";
+my $cfg=read_config($ENV{KB_CONFIG});
+
+my $DEPLOY=$cfg->{'global'}->{deploydir};
+
+print STDERR "PP: $DEPLOY\n";
+open(D,"> $DEPLOY/kbtestserv.log") or die "Unable to open $DEPLOY/kbtestserv.log";
+print D "Yes!\n";
+close D;

--- a/t/deploy.t
+++ b/t/deploy.t
@@ -146,6 +146,7 @@ print C "repobase=$repobase\n";
 print C "devcontainer=$dc\n";
 print C "default-modules=\n";
 print C "deploydir=$base/deployment\n";
+print C "make-options=DEPLOY_RUNTIME=\$KB_RUNTIME ANT_HOME=\$KB_RUNTIME/ant TARGET=$base/deployment\n";
 print C "runtime=$kbrt\n";
 print C "[dev_container]\n";
 print C "type=lib\n";
@@ -258,7 +259,7 @@ ok(KBDeploy::deploy_service($tf,0,1),0);
 ok(defined $cfg->{deployed}->{$testrepo});
 ok($cfg->{deployed}->{$testrepo}->{hash},$hash);
 ok($cfg->{services}->{$testrepo}->{hash},$hash);
-ok(-e "$base/deployment/kbtestserv.log");
+ok(-e "$base/deployment/kbtestserv.log") or exit;
 
 # update without a change
 print "# run update, but nothing has changed\n";


### PR DESCRIPTION

Fixes for travis.  In a nutshell, the wrong perl was being used (fixed with setting KB_RUNTIME to the perlbrew path) and some portions were getting deployed to /kb/deployment (fixed with the make-options change).