### PR TITLE
postprocess_aweworker support for multiple AWE client processes

### DIFF
--- a/config/postprocess_aweworker
+++ b/config/postprocess_aweworker
@@ -33,31 +33,59 @@ $mcfg->newval('Client','serverurl',$cfg->{services}->{$service}->{'serverurl'}) 
 $mcfg->setval('Client','supported_apps','*');
 $mcfg->setval('Client','name','hostname');
 
-my $defaultdone=0;
+#my $defaultdone=0;
+my @aweGroups;
 foreach my $token (split /,/,$cfg->{services}->{$service}->{'tokens'}){
   my @l=split /[=|]/,$token;
   my $group=$l[1];
+  push @aweGroups,$group;
   $mcfg->setval('Client','group',$group);
   $mcfg->setval('Client','clientgroup_token',$token);
+  $mcfg->setval('Client','workpath',$cfg->{'services'}->{$service}->{'baseworkdir'} . '/' . $group . '/work');
+  $mcfg->setval('Directories','data',$cfg->{'services'}->{$service}->{'baseworkdir'} . '/' . $group . '/data');
+  $mcfg->setval('Directories','logs',$cfg->{'services'}->{$service}->{'baseworkdir'} . '/' . $group . '/logs');
   my $out=$file;
-  if ($defaultdone == 1){
+#  if ($defaultdone == 1){
     $out=~s/cfg$//;
     $out.="$group.cfg";
-    $defaultdone=1;
-  }
+#    $defaultdone=1;
+#  }
   print "Updating $out\n";
   $mcfg->WriteConfig($out) or die "Unable to write $file";
 }
 
-mysystem("cp $KB_DEPLOY/services/awe_service/start_{aweclient,service}");
-mysystem("cp $KB_DEPLOY/services/awe_service/stop_{aweclient,service}");
+#mysystem("cp $KB_DEPLOY/services/awe_service/start_{aweclient,service}");
+#mysystem("cp $KB_DEPLOY/services/awe_service/stop_{aweclient,service}");
+
+foreach my $action ('start','stop')
+{
+  my $script=<<EOF;
+#!/bin/bash
+for worker in @aweGroups
+do
+    $KB_DEPLOY/services/awe_service/${action}_aweclient \$worker
+done
+EOF
+
+  my $scriptfile="$KB_DEPLOY/services/awe_service/${action}_service";
+  open (SCRIPT, '>', $scriptfile) or die "couldn't open $scriptfile: $!";
+  print SCRIPT $script;
+  close SCRIPT;
+
+  my $baseworkdir=$cfg->{'services'}->{$service}->{'baseworkdir'};
+  # need to protect / in $baseworkdir.  yay leaning toothpick syndrome!
+  $baseworkdir=~s/\//\\\//g;
+  # kkeller: i use perl as my sed
+  mysystem("perl -pi -e 's/^PID_FILE=.*/PID_FILE=$baseworkdir\\\/client\\\$suffix.pid/;' $KB_DEPLOY/services/awe_service/${action}_aweclient");
+  mysystem("perl -pi -e 's/^AWE_DIR=.*/AWE_DIR=$baseworkdir/;' $KB_DEPLOY/services/awe_service/${action}_aweclient");
+}
 
 # May not be needed anymore.  Check.
 mysystem("sed -i 's/\\/\\/kbase.us/\\/\\/".$base_url."\\//' $KB_DEPLOY/plbin/njs*");
 mysystem("sed -i 's/\\/\\/tutorial.theseed.org/\\/\\/".$base_url."\\//' $KB_DEPLOY/plbin/njs*");
 mysystem("touch $KB_DEPLOY/lib/biokbase/AbstractHandle/__init__.py");
 
-# 
+#
 # Get assembly scripts
 # TODO: remove this hack
 if ( ! -e "$KB_DEPLOY/bin/assemble_contigset_from_reads") {

--- a/config/postprocess_aweworker
+++ b/config/postprocess_aweworker
@@ -33,7 +33,6 @@ $mcfg->newval('Client','serverurl',$cfg->{services}->{$service}->{'serverurl'}) 
 $mcfg->setval('Client','supported_apps','*');
 $mcfg->setval('Client','name','hostname');
 
-#my $defaultdone=0;
 my @aweGroups;
 foreach my $token (split /,/,$cfg->{services}->{$service}->{'tokens'}){
   my @l=split /[=|]/,$token;
@@ -45,17 +44,11 @@ foreach my $token (split /,/,$cfg->{services}->{$service}->{'tokens'}){
   $mcfg->setval('Directories','data',$cfg->{'services'}->{$service}->{'baseworkdir'} . '/' . $group . '/data');
   $mcfg->setval('Directories','logs',$cfg->{'services'}->{$service}->{'baseworkdir'} . '/' . $group . '/logs');
   my $out=$file;
-#  if ($defaultdone == 1){
     $out=~s/cfg$//;
     $out.="$group.cfg";
-#    $defaultdone=1;
-#  }
   print "Updating $out\n";
   $mcfg->WriteConfig($out) or die "Unable to write $file";
 }
-
-#mysystem("cp $KB_DEPLOY/services/awe_service/start_{aweclient,service}");
-#mysystem("cp $KB_DEPLOY/services/awe_service/stop_{aweclient,service}");
 
 foreach my $action ('start','stop')
 {
@@ -85,7 +78,6 @@ mysystem("sed -i 's/\\/\\/kbase.us/\\/\\/".$base_url."\\//' $KB_DEPLOY/plbin/njs
 mysystem("sed -i 's/\\/\\/tutorial.theseed.org/\\/\\/".$base_url."\\//' $KB_DEPLOY/plbin/njs*");
 mysystem("touch $KB_DEPLOY/lib/biokbase/AbstractHandle/__init__.py");
 
-#
 # Get assembly scripts
 # TODO: remove this hack
 if ( ! -e "$KB_DEPLOY/bin/assemble_contigset_from_reads") {


### PR DESCRIPTION
Revised functionality to start multiple aweworkers on one VM.  With these changes, everything that's needed should all be in the config file for each AWE clientgroup, and in each config file directories are configured based on the group name.  The new start_service and stop_service scripts only call start_aweclient or stop_aweclient for each group.  The awec.cfg file is no longer used in this deployment strategy.  The PID file and startup logs are also moved out of the deployment directory (to accomodate sharing the deployment directory among multiple AWE worker VMs).

The hacks of the *_aweclient scripts are awful; ideally the changes should go to the AWE code, but I am too lazy to do that coding right now.