### PR TITLE
configure postprocess_narrative properly

### DIFF
--- a/config/postprocess_narrative
+++ b/config/postprocess_narrative
@@ -33,6 +33,8 @@ my $njsw=$scfg->{'njsw-url'};
 my $njp=$scfg->{'njp-url'};
 my $trans=$scfg->{'transform-url'};
 my $wsid=$scfg->{'example-wsid'};
+my $baseconfig=$cfg->{global}->{'basename'};
+$baseconfig='prod' if $baseconfig=~/prod/;
 
 my $nginxcfg="/etc/nginx/sites-available/default";
 mysystem('sed -i \'s/narrative.kbase.us/'.$narr_host.'/\' '.$DT."/config/narrative.nginx");
@@ -87,6 +89,7 @@ $njsw=~s/\//\\\//g;
 mysystem('sed -i "s/\"job_service\":.*/\"job_service\": \"'.$njsw.'\",/" '.$cj);
 $trans=~s/\//\\\//g;
 mysystem('sed -i "s/\"transform\":.*/\"transform\": \"'.$trans.'\",/" '.$cj);
+mysystem('sed -i "s/\"config\": \"ci\"/\"config\": \"'.$baseconfig.'\"/" '.$cj);
 
 # Fix up example tab
 # Replace: exampleWsId: 2901, // designed to be a workspace with just a handful of objects


### PR DESCRIPTION
I think there was a recent change to the narrative src/config.json file which sets the "ci" stanza of that file as the default.  These changes substitute the name of the deployment, and are tested in -next.  Since our production deploys are named proda and prodb, I also have a line that replaces either of those (or anything with "prod" in it) with prod (untested).

I should make sure this change or a moral equivalent makes xcat.chicago's deploy_tools before Thursday.